### PR TITLE
fixed "keyborad" typos

### DIFF
--- a/FocusLogger/JocysCom.FocusLogger.csproj
+++ b/FocusLogger/JocysCom.FocusLogger.csproj
@@ -8,7 +8,7 @@
 	<Authors>Jocys.com</Authors>
 	<Company>Jocys.com</Company>
 	<Product>Focus Logger</Product>
-	<Description>Find out which process or program is taking the window focus. In game, mouse and keyborad could start temporary stop responding if other program takes the focus. This tools could help to find out which program steals the focus.</Description>
+	<Description>Find out which process or program is taking the window focus. In game, mouse and keyboard could start temporary stop responding if other program takes the focus. This tools could help to find out which program steals the focus.</Description>
 	<ApplicationIcon>App.ico</ApplicationIcon>
 	<Version>1.0.9</Version>
 	<RepositoryUrl>https://github.com/JocysCom/FocusLogger</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Find out which process or program is taking the window focus.
 
-In game, mouse and keyborad could start temporary stop responding if other program takes the focus. This tools could help to find out which program steals the focus.
+In game, mouse and keyboard could start temporary stop responding if other program takes the focus. This tools could help to find out which program steals the focus.
 
 # Download
 


### PR DESCRIPTION
Typos were present in Readme and in the main window of the app itself