### PR TITLE
PR: #9: FIX: Add Window Class column to help identify focus stealers

### DIFF
--- a/.ai/coding-guideline.instructions.md
+++ b/.ai/coding-guideline.instructions.md
@@ -57,6 +57,7 @@ Naming conventions for issues, branches, and pull requests.
 - Feature branches are always created from `main` or `master`. Never merge one feature branch into another — only merge `main` if you need to catch up.
 - Always create branches from latest origin/main or origin/main, never merge sub-branches, confirm before risky git ops.
 - Do not add Co-Authored-By {AI model}/{AI company} lines to commits.
+- Never close issues before a release is published with the fix.
 
 Use the following guidelines:
 

--- a/.claude/coding-guideline.instructions.md
+++ b/.claude/coding-guideline.instructions.md
@@ -57,6 +57,7 @@ Naming conventions for issues, branches, and pull requests.
 - Feature branches are always created from `main` or `master`. Never merge one feature branch into another — only merge `main` if you need to catch up.
 - Always create branches from latest origin/main or origin/main, never merge sub-branches, confirm before risky git ops.
 - Do not add Co-Authored-By {AI model}/{AI company} lines to commits.
+- Never close issues before a release is published with the fix.
 
 Use the following guidelines:
 

--- a/.github/instructions/coding-guideline.instructions.md
+++ b/.github/instructions/coding-guideline.instructions.md
@@ -57,6 +57,7 @@ Naming conventions for issues, branches, and pull requests.
 - Feature branches are always created from `main` or `master`. Never merge one feature branch into another — only merge `main` if you need to catch up.
 - Always create branches from latest origin/main or origin/main, never merge sub-branches, confirm before risky git ops.
 - Do not add Co-Authored-By {AI model}/{AI company} lines to commits.
+- Never close issues before a release is published with the fix.
 
 Use the following guidelines:
 

--- a/FocusLogger.Tests/CsvExportTests.cs
+++ b/FocusLogger.Tests/CsvExportTests.cs
@@ -57,6 +57,7 @@ namespace JocysCom.FocusLogger.Tests
 					HasKeyboard = true,
 					HasCaret = true,
 					WindowTitle = "Untitled - Notepad",
+					WindowClassName = "Notepad",
 					ProcessPath = @"C:\Windows\notepad.exe",
 				},
 				new DataItem
@@ -69,13 +70,14 @@ namespace JocysCom.FocusLogger.Tests
 					HasKeyboard = false,
 					HasCaret = false,
 					WindowTitle = "File, \"Explorer\"",
+					WindowClassName = "CabinetWClass",
 					ProcessPath = @"C:\Windows\explorer.exe",
 				},
 			};
 			var csv = DataListControl.BuildCsvContent(items);
 			var lines = csv.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
 			// Header + 2 data rows + trailing empty line.
-			Assert.AreEqual("Date,PID,Process Name,Active,Mouse,Keyboard,Caret,Window Title,Path", lines[0]);
+			Assert.AreEqual("Date,PID,Process Name,Active,Mouse,Keyboard,Caret,Window Title,Window Class,Path", lines[0]);
 			Assert.AreEqual(4, lines.Length);
 			// Verify comma/quote in WindowTitle is escaped.
 			Assert.IsTrue(lines[2].Contains("\"File, \"\"Explorer\"\"\""));
@@ -87,7 +89,7 @@ namespace JocysCom.FocusLogger.Tests
 			var csv = DataListControl.BuildCsvContent(Array.Empty<DataItem>());
 			var lines = csv.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
 			Assert.AreEqual(1, lines.Length);
-			Assert.AreEqual("Date,PID,Process Name,Active,Mouse,Keyboard,Caret,Window Title,Path", lines[0]);
+			Assert.AreEqual("Date,PID,Process Name,Active,Mouse,Keyboard,Caret,Window Title,Window Class,Path", lines[0]);
 		}
 	}
 }

--- a/FocusLogger/Common/DataItem.cs
+++ b/FocusLogger/Common/DataItem.cs
@@ -23,6 +23,9 @@ namespace JocysCom.FocusLogger
 		public string WindowTitle { get => _WindowTitle; set => SetProperty(ref _WindowTitle, value); }
 		string _WindowTitle;
 
+		public string WindowClassName { get => _WindowClassName; set => SetProperty(ref _WindowClassName, value); }
+		string _WindowClassName;
+
 		public bool HasMouse { get => _HasMouse; set => SetProperty(ref _HasMouse, value); }
 		bool _HasMouse;
 

--- a/FocusLogger/Common/NativeMethods.cs
+++ b/FocusLogger/Common/NativeMethods.cs
@@ -143,6 +143,16 @@ namespace JocysCom.FocusLogger
 			return null;
 		}
 
+		[DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+		static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+		internal static string GetWindowClassName(IntPtr hWnd)
+		{
+			var sb = new StringBuilder(256);
+			var length = GetClassName(hWnd, sb, sb.Capacity);
+			return length > 0 ? sb.ToString() : "";
+		}
+
 		internal static string GetWindowText(IntPtr hWnd)
 		{
 			int textLength = GetWindowTextLengthW(hWnd);

--- a/FocusLogger/Controls/DataListControl.xaml
+++ b/FocusLogger/Controls/DataListControl.xaml
@@ -274,12 +274,6 @@
 					ElementStyle="{StaticResource TextBlockCell}"
 					Header="Window Title" />
 				<DataGridTextColumn
-					x:Name="WindowClassNameColumn"
-					Binding="{Binding WindowClassName}"
-					EditingElementStyle="{StaticResource TextBoxCell}"
-					ElementStyle="{StaticResource TextBlockCell}"
-					Header="Window Class" />
-				<DataGridTextColumn
 					x:Name="ProcessPathColumn"
 					Width="Auto"
 					x:FieldModifier="public"
@@ -294,6 +288,12 @@
 						</MultiBinding>
 					</DataGridTextColumn.Binding>
 				</DataGridTextColumn>
+				<DataGridTextColumn
+					x:Name="WindowClassNameColumn"
+					Binding="{Binding WindowClassName}"
+					EditingElementStyle="{StaticResource TextBoxCell}"
+					ElementStyle="{StaticResource TextBlockCell}"
+					Header="Window Class" />
 			</DataGrid.Columns>
 			<DataGrid.CellStyle>
 				<Style TargetType="DataGridCell">

--- a/FocusLogger/Controls/DataListControl.xaml
+++ b/FocusLogger/Controls/DataListControl.xaml
@@ -274,6 +274,12 @@
 					ElementStyle="{StaticResource TextBlockCell}"
 					Header="Window Title" />
 				<DataGridTextColumn
+					x:Name="WindowClassNameColumn"
+					Binding="{Binding WindowClassName}"
+					EditingElementStyle="{StaticResource TextBoxCell}"
+					ElementStyle="{StaticResource TextBlockCell}"
+					Header="Window Class" />
+				<DataGridTextColumn
 					x:Name="ProcessPathColumn"
 					Width="Auto"
 					x:FieldModifier="public"

--- a/FocusLogger/Controls/DataListControl.xaml.cs
+++ b/FocusLogger/Controls/DataListControl.xaml.cs
@@ -151,7 +151,7 @@ namespace JocysCom.FocusLogger.Controls
 		{
 			var prompt = ClassLibrary.Helper.FindResource<string>("Resources/AiAnalysisPrompt.md").TrimEnd();
 			var box = new MessageBoxWindow();
-			box.SetSize(600, 400);
+			box.SetSize(720, 400);
 			box.ShowPrompt(prompt, "AI Analysis Prompt - Copy and paste into your AI assistant", MessageBoxButton.OK, MessageBoxImage.Information, MessageBoxResult.OK);
 		}
 

--- a/FocusLogger/Controls/DataListControl.xaml.cs
+++ b/FocusLogger/Controls/DataListControl.xaml.cs
@@ -119,7 +119,7 @@ namespace JocysCom.FocusLogger.Controls
 		public static string BuildCsvContent(System.Collections.Generic.IEnumerable<DataItem> items)
 		{
 			var sb = new StringBuilder();
-			sb.AppendLine("Date,PID,Process Name,Active,Mouse,Keyboard,Caret,Window Title,Path");
+			sb.AppendLine("Date,PID,Process Name,Active,Mouse,Keyboard,Caret,Window Title,Window Class,Path");
 			foreach (var item in items)
 			{
 				sb.AppendLine(string.Join(",",
@@ -131,6 +131,7 @@ namespace JocysCom.FocusLogger.Controls
 					item.HasKeyboard,
 					item.HasCaret,
 					CsvEscape(item.WindowTitle),
+					CsvEscape(item.WindowClassName),
 					CsvEscape(item.ProcessPath)
 				));
 			}
@@ -280,6 +281,7 @@ namespace JocysCom.FocusLogger.Controls
 				hWnd = NativeMethods.GetTopWindow(hWnd);
 			}
 			item.WindowTitle = NativeMethods.GetWindowText(hWnd);
+			item.WindowClassName = NativeMethods.GetWindowClassName(hWnd);
 			NativeMethods.GetWindowThreadProcessId(hWnd, out processId);
 			item.ProcessId = processId;
 			return item;

--- a/FocusLogger/Resources/AiAnalysisPrompt.md
+++ b/FocusLogger/Resources/AiAnalysisPrompt.md
@@ -1,9 +1,12 @@
 I have a Focus Logger CSV file that records which Windows process or program takes window focus.
-Each row contains: Date, PID, Process Name, Active, Mouse, Keyboard, Caret, Window Title, and Path.
+Each row contains: Date, PID, Process Name, Active, Mouse, Keyboard, Caret, Window Title, Window Class, and Path.
+
+The "Window Class" column contains the Win32 window class name (e.g., "Shell_TrayWnd" for the taskbar, "tooltips_class32" for tooltip popups, "MSCTFIME UI" for text input framework, "Chrome_WidgetWin_1" for Chromium-based browsers). This helps identify the type of window that took focus.
 
 Please analyse the attached CSV file and:
 1. Identify which processes are stealing focus unexpectedly (e.g., briefly appearing then disappearing).
-2. Flag any unusual patterns such as rapid focus switching, background processes taking foreground, or processes that shouldn't normally grab focus.
-3. If a game or fullscreen application is present, highlight any process that interrupted it.
-4. Summarise the most frequent focus-stealing offenders with timestamps.
-5. Suggest possible causes and fixes for each offender.
+2. Use the Window Class to determine what type of window stole focus (notification, tooltip, taskbar, input method, dialog, etc.) and explain what it means.
+3. Flag any unusual patterns such as rapid focus switching, background processes taking foreground, or processes that shouldn't normally grab focus.
+4. If a game or fullscreen application is present, highlight any process that interrupted it.
+5. Summarise the most frequent focus-stealing offenders with timestamps.
+6. Suggest possible causes and fixes for each offender.


### PR DESCRIPTION
## Summary
- Add **Window Class** column to the DataGrid showing the Win32 window class name (e.g., `Shell_TrayWnd`, `MSCTFIME UI`, `tooltips_class32`)
- Helps users identify *what type* of window stole focus, not just which process
- Include Window Class in CSV export
- Update AI analysis prompt to leverage Window Class for better diagnosis

## Changes
- `NativeMethods.cs` — Add `GetClassName` P/Invoke and `GetWindowClassName` wrapper
- `DataItem.cs` — Add `WindowClassName` property
- `DataListControl.xaml.cs` — Capture window class in `GetItemFromHandle`, include in CSV
- `DataListControl.xaml` — Add Window Class column between Window Title and Path
- `AiAnalysisPrompt.md` — Updated with Window Class context and guidance
- `CsvExportTests.cs` — Updated to match new CSV format

Closes #9