### PR TITLE
Bug: 44: Sorting by Path column doesn't work

### DIFF
--- a/FocusLogger.Tests/SortableBindingListTests.cs
+++ b/FocusLogger.Tests/SortableBindingListTests.cs
@@ -13,8 +13,14 @@ namespace JocysCom.FocusLogger.Tests
 		private static PropertyDescriptor DateDescriptor()
 			=> TypeDescriptor.GetProperties(typeof(DataItem))[nameof(DataItem.Date)];
 
+		private static PropertyDescriptor ProcessPathDescriptor()
+			=> TypeDescriptor.GetProperties(typeof(DataItem))[nameof(DataItem.ProcessPath)];
+
 		private static DataItem ItemAt(DateTime date)
 			=> new DataItem { Date = date };
+
+		private static DataItem ItemWithPath(string path)
+			=> new DataItem { ProcessPath = path };
 
 		[TestMethod]
 		public void ApplySort_ByDateAscending_OrdersByActualDateTime()
@@ -58,6 +64,49 @@ namespace JocysCom.FocusLogger.Tests
 					new DateTime(2026, 4, 4, 10, 30, 0, 0),
 				},
 				list.Select(x => x.Date).ToArray());
+		}
+
+		[TestMethod]
+		public void ApplySort_ByProcessPathAscending_OrdersLexicographically()
+		{
+			// Mirrors the Date-sort tests: confirms that once the Path column wires
+			// SortMemberPath="ProcessPath" through to SortableBindingList, string
+			// values sort alphabetically via PropertyComparer<DataItem>.
+			var list = new SortableBindingList<DataItem>
+			{
+				ItemWithPath(@"C:\Windows\explorer.exe"),
+				ItemWithPath(@"C:\Program Files\App\app.exe"),
+				ItemWithPath(@"D:\Tools\utility.exe"),
+			};
+			((IBindingList)list).ApplySort(ProcessPathDescriptor(), ListSortDirection.Ascending);
+			CollectionAssert.AreEqual(
+				new[]
+				{
+					@"C:\Program Files\App\app.exe",
+					@"C:\Windows\explorer.exe",
+					@"D:\Tools\utility.exe",
+				},
+				list.Select(x => x.ProcessPath).ToArray());
+		}
+
+		[TestMethod]
+		public void ApplySort_ByProcessPathDescending_OrdersLexicographicallyReversed()
+		{
+			var list = new SortableBindingList<DataItem>
+			{
+				ItemWithPath(@"C:\Program Files\App\app.exe"),
+				ItemWithPath(@"D:\Tools\utility.exe"),
+				ItemWithPath(@"C:\Windows\explorer.exe"),
+			};
+			((IBindingList)list).ApplySort(ProcessPathDescriptor(), ListSortDirection.Descending);
+			CollectionAssert.AreEqual(
+				new[]
+				{
+					@"D:\Tools\utility.exe",
+					@"C:\Windows\explorer.exe",
+					@"C:\Program Files\App\app.exe",
+				},
+				list.Select(x => x.ProcessPath).ToArray());
 		}
 
 		[TestMethod]

--- a/FocusLogger/Controls/DataListControl.xaml
+++ b/FocusLogger/Controls/DataListControl.xaml
@@ -286,7 +286,8 @@
 					x:FieldModifier="public"
 					EditingElementStyle="{StaticResource TextBoxCell}"
 					ElementStyle="{StaticResource TextBlockCell}"
-					Header="Path">
+					Header="Path"
+					SortMemberPath="ProcessPath">
 					<DataGridTextColumn.Binding>
 						<MultiBinding Converter="{StaticResource _MainDataGridFormattingConverter}">
 							<Binding RelativeSource="{RelativeSource Self}" />

--- a/FocusLogger/JocysCom.FocusLogger.csproj
+++ b/FocusLogger/JocysCom.FocusLogger.csproj
@@ -10,7 +10,7 @@
 	<Product>Focus Logger</Product>
 	<Description>Find out which process or program is taking the window focus. In game, mouse and keyboard could temporarily stop responding if another program takes the focus. This tool could help diagnose which program is stealing the focus.</Description>
 	<ApplicationIcon>App.ico</ApplicationIcon>
-	<Version>1.3.10</Version>
+	<Version>1.3.11</Version>
 	<RepositoryUrl>https://github.com/JocysCom/FocusLogger</RepositoryUrl>
 	<PackageProjectUrl>https://www.jocys.com</PackageProjectUrl>
 	<Copyright>Copyright © Jocys.com 2026</Copyright>


### PR DESCRIPTION
Closes #44

## Root cause
The Path column's text is produced through a `MultiBinding` (routed via `ItemFormattingConverter`). WPF's `DataGrid` cannot infer a sort property from a `MultiBinding`, so clicking the column header was a silent no-op — no sort, no direction triangle.

## Fix
Declare the sort property explicitly with `SortMemberPath="ProcessPath"` on `ProcessPathColumn` in `FocusLogger/Controls/DataListControl.xaml`, exactly mirroring the working `DateColumn` template (which uses the same `MultiBinding` + `SortMemberPath="Date"` pattern). `SortableBindingList<T>` + `PropertyComparer<T>` already do the actual ordering — `ProcessPath` is a `string` (`IComparable`), so lexicographic sorting works as soon as the descriptor reaches `ApplySortCore`.

Bumps `<Version>` from 1.3.10 -> 1.3.11.

## Regression coverage
`FocusLogger.Tests/SortableBindingListTests.cs`:
- `ApplySort_ByProcessPathAscending_OrdersLexicographically`
- `ApplySort_ByProcessPathDescending_OrdersLexicographicallyReversed`

## Verification
- The change is a single XAML attribute on a `DataGridTextColumn` whose only difference from `DateColumn` was the missing `SortMemberPath` — the diff and pattern match are recorded in `.tmp/code-work-item/evidence/`.
- Unit tests assert the underlying `IBindingList.ApplySort` path returns the expected ordering.
- The WPF host (`net8.0-windows`, `UseWPF=true`) cannot be built on the Linux agent container; visual confirmation of the column header click is expected to be performed by the reviewer on Windows.